### PR TITLE
25 a way of roolback river formation required

### DIFF
--- a/element-front/src/components/PlayerMenu/ElementContainer.vue
+++ b/element-front/src/components/PlayerMenu/ElementContainer.vue
@@ -69,6 +69,7 @@ export default defineComponent({
         },
         onResetView(){
             this.selectedElement = NON_SELECTED;
+            this.$emit('elementClickedIndex', NON_SELECTED);
         }
 
     }

--- a/element-front/src/composables/Board.vue
+++ b/element-front/src/composables/Board.vue
@@ -63,7 +63,8 @@ export default defineComponent({
       }
     })
     Emitter.on('riverCancel', () => {
-      this.waterUtils?.resetBuldingRiver(this.board!);
+      this.waterUtils?.cancelBuildingRiver(this.board!);
+      Emitter.emit('resetPlayerMenu');
     })
     Emitter.on('riverUndo', () => {
       this.waterUtils!.waterElementSM = 'Undoing';

--- a/element-front/src/composables/Board/WaterUtils.ts
+++ b/element-front/src/composables/Board/WaterUtils.ts
@@ -176,6 +176,20 @@ class WaterUtils {
     })
   }
 
+  cancelBuildingRiver(board: BoardModel): void {
+    this.restoreNewRiver(board);
+    this.restoreOldRiver(board);
+    const gridController: GridController = new GridController(board.grid);
+    gridController.clearCell(this.placedWater.position)
+    nextTick(()=>{
+      // Negative positions to reset empty spaces
+      Emitter.emit('NewRiverAvailablePlacement', {row: -2, column: -2});
+      this.waterElementSM = "None";
+      Emitter.emit('sysLog', `River cancelled`)
+    })
+
+  }
+
   undoRiverBuildingStep(board: BoardModel): void {
     const gridController: GridController = new GridController(board.grid);
     if(this.newRiver.length == 0){


### PR DESCRIPTION
Now the cancel button in the river formation rolls back to before placing the water. This is necessary when adding a water that builds up a river but the river does not have enough available empty spaces to be built.